### PR TITLE
Fix channel collection population and several archive bugs

### DIFF
--- a/internetarchive_youtube/archive_youtube.py
+++ b/internetarchive_youtube/archive_youtube.py
@@ -154,7 +154,7 @@ class ArchiveYouTube:
         data = [x for x in data if not x['downloaded'] or not x['uploaded']]
         data = [
             x for x in data if x['downloaded'] != 'not available'
-            or x['uploaded'] != 'not available'
+            and x['uploaded'] != 'not available'
         ]
 
         random.shuffle(data)
@@ -408,20 +408,25 @@ class ArchiveYouTube:
             if not is_downloaded:
                 return
 
-            if mongodb:
-                col.update_one({'_id': _id}, {
-                    '$set': {
-                        'downloaded': is_downloaded,
-                        'uploaded': is_downloaded
-                    }
-                })
-            elif jsonbin:
-                video['downloaded'] = is_downloaded
-                video['uploaded'] = is_downloaded
-                jb.update_bin(bin_id, self._data)
-
             if is_downloaded == 'not available':
+                if mongodb:
+                    col.update_one({'_id': _id}, {
+                        '$set': {
+                            'downloaded': 'not available',
+                            'uploaded': 'not available'
+                        }
+                    })
+                elif jsonbin:
+                    video['downloaded'] = 'not available'
+                    video['uploaded'] = 'not available'
+                    jb.update_bin(bin_id, self._data)
                 return
+
+            if mongodb:
+                col.update_one({'_id': _id}, {'$set': {'downloaded': True}})
+            elif jsonbin:
+                video['downloaded'] = True
+                jb.update_bin(bin_id, self._data)
 
             logger.debug('✅ Downloaded!')
             time.sleep(3)
@@ -458,6 +463,14 @@ class ArchiveYouTube:
 
         mongodb, jsonbin, col, jb, bin_id, data = self.load_data()
         self._data = data
+
+        if not data:
+            logger.warning(
+                'No videos to process. If this is your first run, '
+                'populate the database first with: '
+                'internetarchive-youtube --create-collection')
+            return
+
         input_dict = {
             'mongodb': mongodb,
             'jsonbin': jsonbin,

--- a/internetarchive_youtube/cli.py
+++ b/internetarchive_youtube/cli.py
@@ -138,9 +138,13 @@ def _create_collection(no_logs: bool = False) -> None:
             channels = f.read()
 
     try:
-        channels = json.loads(channels).items()
+        channels = list(json.loads(channels).items())
     except json.decoder.JSONDecodeError:
-        channels = [tuple(x.split(': ')) for x in channels.strip().split('\n')]
+        channels = [
+            tuple(x.split(': ', 1))
+            for x in channels.strip().split('\n')
+            if x.strip() and ': ' in x
+        ]
 
     random.shuffle(channels)
 
@@ -159,14 +163,14 @@ def main() -> None:
     signal.signal(signal.SIGALRM, _alarm_handler)
     timeout = int(args.timeout * 3600)
 
-    if args.create_collection:
-        _create_collection(no_logs=args.no_logs)
-        sys.exit(0)
-
     if not args.channels_file:
         args.channels_file = f'{Path.home()}/.yt_channels.txt'
         if not os.getenv('CHANNELS'):
             os.environ['CHANNELS'] = args.channels_file
+
+    if args.create_collection:
+        _create_collection(no_logs=args.no_logs)
+        sys.exit(0)
 
     if args.show_channels:
         chs_file = Path(args.channels_file)

--- a/internetarchive_youtube/create_collection.py
+++ b/internetarchive_youtube/create_collection.py
@@ -136,13 +136,13 @@ class CreateCollection:
 
         last_ten_ids = [x['_id'] for x in data]
 
-        if all(True if x in last_ten_ids else False for x in existing_ids):
+        if last_ten_ids and all(x in existing_ids for x in last_ten_ids):
             logger.debug(
                 f'{self.channel_name} is up-to-date! Nothing to do...')
             return
         else:
             data = [x for x in data if x['_id'] not in existing_ids]
-            if 10 > len(data):
+            if len(data) < 10:
                 skip_full_download = True
                 logger.debug(f'Found {len(data)} new videos...')
 
@@ -150,7 +150,7 @@ class CreateCollection:
             logger.debug(
                 'Downloading the entire channel metadata... This might take '
                 'few minutes...')
-            cmd = self.info_cmd(self.channel_url)
+            cmd = self.info_cmd()
             p = subprocess.run(shlex.split(cmd),
                                shell=False,
                                check=True,


### PR DESCRIPTION
## Summary

- **Root cause of \"Videos: 0it\" (new-user bug):** The up-to-date check in `create_collection.py` iterated over `existing_ids` instead of `last_ten_ids`. When the database is empty, `all(... for x in [])` is vacuously `True`, so the function returned "is up-to-date!" before ever inserting anything. Fixed to `all(x in existing_ids for x in last_ten_ids)`, with a `last_ten_ids` guard so an empty fetch (private channel, network issue) doesn't also skip.
- **Full-channel yt-dlp command was broken:** `self.info_cmd(self.channel_url)` passed the channel URL as the `playlist_end` parameter, duplicating it in the shell command. Fixed to `self.info_cmd()`.
- **Premature `uploaded=True` after download:** The DB was set to `downloaded=True, uploaded=True` immediately after downloading. If the process crashed before the upload, the video was permanently orphaned (never retried). Now only `downloaded=True` is written after download; `uploaded=True` is written only after a confirmed 200 response.
- **`load_data` filter bug:** The filter for `'not available'` records used `or` instead of `and`, letting partially-marked videos slip through. Fixed to `and`.
- **Actionable empty-data warning:** Instead of a silent `Videos: 0it [00:00, ?it/s]`, the run now logs a message pointing the user to `--create-collection`.
- **`channels_file` default applied too late:** The default `~/.yt_channels.txt` was only set after the `--create-collection` branch, so `internetarchive-youtube -C` without `-c` never found the file. Default is now applied before the branch.
- **`random.shuffle` crash on JSON channel lists:** `json.loads(...).items()` returns a `dict_items` view which isn't shuffleable. Wrapped in `list()`.
- **Empty/malformed lines in channels file:** Blank lines and lines missing `': '` produced single-element tuples, causing `IndexError` on `channel[1]`. Now filtered out. Also changed to `split(': ', 1)` so URLs containing `': '` aren't split incorrectly.

## Test plan

- [ ] Fresh install with an empty MongoDB: run `internetarchive-youtube -C` and confirm videos are inserted into the database
- [ ] Run `internetarchive-youtube` with a populated DB and confirm videos are downloaded then uploaded (not skipped due to premature `uploaded=True`)
- [ ] Run `internetarchive-youtube` with an empty DB (no `--create-collection` first) and confirm the new warning message is shown
- [ ] Run `internetarchive-youtube -C` without `-c` flag and confirm it picks up `~/.yt_channels.txt`
- [ ] Channels file with blank lines / comments — confirm they are silently skipped rather than causing a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)