### PR TITLE
Fix JSONBin API compatibility and additional bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ source "$HOME/.$(basename $SHELL)rc"
 #### ⌨️ Usage:
 
 ```
-usage: ia-yt [-h] [-p PRIORITIZE] [-s SKIP_LIST] [-f] [-t TIMEOUT] [-n] [-a] [-c CHANNELS_FILE] [-S] [-C] [-m] [-T THREADS] [-k] [-i IGNORE_VIDEO_IDS]
+usage: ia-yt [-h] [-p PRIORITIZE] [-s SKIP_LIST] [-f] [-t TIMEOUT] [-n] [-a] [-c CHANNELS_FILE] [-S] [-C] [-m] [-T THREADS] [-k] [-i IGNORE_VIDEO_IDS] [-A] [-SC SPECIFIC_CHANNEL] [-co COOKIES_FILE]
 
 options:
   -h, --help            show this help message and exit
@@ -124,7 +124,7 @@ options:
   -f, --force-refresh   Refresh the database after every video (Can slow down the workflow significantly, but is useful when running multiple concurrent
                         jobs).
   -t TIMEOUT, --timeout TIMEOUT
-                        Kill the job after n hours (default: 5.5).
+                        Kill the job after n hours (default: 5).
   -n, --no-logs         Don't print any log messages.
   -a, --add-channel     Add a channel interactively to the list of channels to archive.
   -c CHANNELS_FILE, --channels-file CHANNELS_FILE
@@ -139,6 +139,11 @@ options:
                         Keep the files of failed uploads on the local disk.
   -i IGNORE_VIDEO_IDS, --ignore-video-ids IGNORE_VIDEO_IDS
                         Comma-separated list or a path to a file containing a list of video ids to ignore.
+  -A, --use-aria2c      Use external downloader aria2c (can significantly speed up downloads).
+  -SC SPECIFIC_CHANNEL, --specific-channel SPECIFIC_CHANNEL
+                        Archive one specific channel by name.
+  -co COOKIES_FILE, --cookies-file COOKIES_FILE
+                        Path to a YouTube cookies file (for age-restricted or private videos).
 ```
 
 </details>
@@ -149,8 +154,6 @@ options:
 
 <details>
   <summary>Creating A Backend Database instructions</summary>
-
-  **NOTICE: The `JSONBIN` option will not work at the moment because jsonbin.io changed their API recently. Please use MongoDB for now until the next release.**
 
 - **Option 1:**  MongoDB (recommended).
   - Self-hosted (see: [Alyetama/quick-MongoDB](https://github.com/Alyetama/quick-MongoDB) or [dockerhub image](https://hub.docker.com/_/mongo)).

--- a/internetarchive_youtube/archive_youtube.py
+++ b/internetarchive_youtube/archive_youtube.py
@@ -114,6 +114,7 @@ class ArchiveYouTube:
             except Exception as e:
                 if 'Private video' in str(e) or 'Video unavailable' in str(e):
                     return 'not available'
+                raise
             filename = ydl.prepare_filename(info)
             return Path(filename).suffix
 

--- a/internetarchive_youtube/create_collection.py
+++ b/internetarchive_youtube/create_collection.py
@@ -119,7 +119,7 @@ class CreateCollection:
             jb = JSONBin(os.getenv('JSONBIN_KEY'))
             try:
                 bin_id = jb.handle_collection_bins()
-                existing_data = jb.read_bin(bin_id)
+                existing_data = jb.read_bin(bin_id)['record']
                 existing_ids = [x.get('_id') for x in existing_data]
             except NoDataToInclude:
                 pass

--- a/internetarchive_youtube/jsonbin_manager.py
+++ b/internetarchive_youtube/jsonbin_manager.py
@@ -3,6 +3,9 @@
 
 import requests
 
+BASE_URL = 'https://api.jsonbin.io/v3'
+COLLECTION_NAME = 'yt_archive_sync_collection'
+
 
 class NoDataToInclude(Exception):
     """Raised when there is no data to include."""
@@ -10,6 +13,10 @@ class NoDataToInclude(Exception):
 
 class MissingMasterKey(Exception):
     """Raised when the master key is missing."""
+
+
+class JSONBinError(Exception):
+    """Raised when the JSONBin API returns an error response."""
 
 
 class JSONBin:
@@ -25,87 +32,106 @@ class JSONBin:
         self.jsonbin_key = jsonbin_key
         self.no_logs = no_logs
 
-    def handle_collection_bins(self, include_data=None):
-        """Handle the collection bins.
+    @property
+    def _auth(self) -> dict:
+        return {'X-Master-Key': self.jsonbin_key}
+
+    def _check(self, resp: requests.Response) -> object:
+        """Raise on HTTP error or API-level error message."""
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict) and 'message' in data:
+            raise JSONBinError(data['message'])
+        return data
+
+    def handle_collection_bins(self, include_data=None) -> str:
+        """Return the DATA bin ID, creating the collection/bin if needed.
 
         Args:
-            include_data: Whether to include data or not.
+            include_data: Initial records to store when creating a new bin.
+
+        Returns:
+            The bin ID string.
         """
         if not self.jsonbin_key:
-            raise MissingMasterKey('The secret JSONBIN token can\'t be None!')
+            raise MissingMasterKey("The secret JSONBIN token can't be None!")
 
-        url = 'https://api.jsonbin.io/v3'
+        # --- Find or create the collection ---
+        collections = self._check(
+            requests.get(f'{BASE_URL}/c', headers=self._auth))
 
-        headers = {
-            'X-Collection-Name': 'yt_archive_sync_collection',
-            'X-Master-Key': self.jsonbin_key
-        }
-        data = {}
+        collection_id = None
+        for col in collections:
+            if col.get('collectionMeta', {}).get('name') == COLLECTION_NAME:
+                collection_id = col['record']
+                break
 
-        # CREATE A COLLECTION
+        if not collection_id:
+            data = self._check(
+                requests.post(f'{BASE_URL}/c',
+                              json={},
+                              headers={
+                                  **self._auth,
+                                  'X-Collection-Name': COLLECTION_NAME
+                              }))
+            collection_id = data['record']
 
-        resp = requests.post(f'{url}/c', json=data, headers=headers).json()
-        if resp.get('record'):
-            collection_id = resp['record']
-        else:
-            resp = requests.get(f'{url}/c', json=data, headers=headers)
-            collection_id = resp.json()[0]['record']
+        # --- Find or create the DATA bin ---
+        bins = self._check(
+            requests.get(f'{BASE_URL}/c/{collection_id}/bins',
+                         headers=self._auth))
 
-        # LIST THE BINS OF THE COLLECTION
+        bin_id = None
+        for b in bins:
+            if b.get('snippetMeta', {}).get('name') == 'DATA':
+                bin_id = b['record']
+                break
 
-        resp = requests.get(f'{url}/c/{collection_id}/bins',
-                            json=data,
-                            headers=headers)
-
-        bin_id = [
-            b['record'] for b in resp.json()
-            if b['snippetMeta']['name'] == 'DATA'
-        ]
-        if bin_id:
-            # If the bin exists, return it
-            bin_id = bin_id[0]
-        else:
-            # If not (first run), create a bin with the initial data
+        if not bin_id:
             if not include_data:
                 raise NoDataToInclude
             if not self.no_logs:
                 print('Creating a new bin...')
-            headers.update({
-                'X-Bin-Name': 'DATA',
-                'Content-Type': 'application/json',
-                'X-Collection-Id': collection_id
-            })
-            resp = requests.post(f'{url}/b',
-                                 json=include_data,
-                                 headers=headers)
-            bin_id = resp.json()['metadata']['id']
+            data = self._check(
+                requests.post(f'{BASE_URL}/b',
+                              json=include_data,
+                              headers={
+                                  **self._auth,
+                                  'Content-Type': 'application/json',
+                                  'X-Bin-Name': 'DATA',
+                                  'X-Collection-Id': collection_id,
+                              }))
+            bin_id = data['metadata']['id']
 
         return bin_id
 
-    def read_bin(self, bin_id):
-        """Reads the bin.
+    def read_bin(self, bin_id: str) -> dict:
+        """Read a bin and return the full API response.
 
         Args:
             bin_id: The bin ID.
-        """
-        url = 'https://api.jsonbin.io/v3'
-        headers = {'X-Master-Key': self.jsonbin_key}
-        read_resp = requests.get(f'{url}/b/{bin_id}', headers=headers)
-        return read_resp.json()
 
-    def update_bin(self, bin_id, data):
-        """Updates the bin.
+        Returns:
+            The full response dict with 'record' and 'metadata' keys.
+        """
+        return self._check(
+            requests.get(f'{BASE_URL}/b/{bin_id}', headers=self._auth))
+
+    def update_bin(self, bin_id: str, data) -> dict:
+        """Replace the bin contents.
 
         Args:
             bin_id: The bin ID.
-            data: The data to update.
+            data: The new data to store.
+
+        Returns:
+            The API response dict.
         """
-        url = 'https://api.jsonbin.io/v3'
-        headers = {
-            'X-Master-Key': self.jsonbin_key,
-            'Content-Type': 'application/json'
-        }
-        put_resp = requests.put(f'{url}/b/{bin_id}',
-                                json=data,
-                                headers=headers)
-        return put_resp.json()
+        return self._check(
+            requests.put(f'{BASE_URL}/b/{bin_id}',
+                         json=data,
+                         headers={
+                             **self._auth,
+                             'Content-Type': 'application/json',
+                             'X-Bin-Versioning': 'false',
+                         }))


### PR DESCRIPTION
## Summary

- **JSONBin v3 API is fully broken in the current code** — rewrote `jsonbin_manager.py` to be compatible with the current API
- Fixed a `NameError` in `get_video_extension` that swallowed unexpected yt-dlp errors
- Updated README to remove the stale "JSONBIN will not work" notice and document the three CLI flags added in recent commits

## Changes

### `jsonbin_manager.py` — full rewrite

The old implementation had four separate bugs against the current JSONBin v3 API:

| Bug | Fix |
|-----|-----|
| `GET /v3/c` response is an array of objects; code blindly took `[0]['record']` — wrong collection if user has more than one | Now searches by `collectionMeta.name == 'yt_archive_sync_collection'` |
| GET requests sent an empty JSON body (`json={}`) | Removed the body from all GET calls |
| `b['snippetMeta']['name']` — `KeyError` crash on any bin without a name | Changed to `b.get('snippetMeta', {}).get('name')` |
| `update_bin` created a new version on every write; silent failure at the 1000-version API limit | Added `X-Bin-Versioning: false` header |

Also added a `_check()` helper that raises `JSONBinError` on API-level error messages (`{"message": "..."}`) so failures surface as readable exceptions instead of downstream `KeyError`s.

### `create_collection.py`

`jb.read_bin()` returns `{"record": [...], "metadata": {...}}`. The code was iterating directly over the response dict, so the loop received the string keys `'record'` and `'metadata'` instead of the video list. Added `['record']` extraction (consistent with how `archive_youtube.py` already called it).

### `archive_youtube.py`

In `get_video_extension`, any yt-dlp exception that wasn't "Private video" or "Video unavailable" fell silently through the `except` block, leaving `info` undefined. The next line `ydl.prepare_filename(info)` then raised `NameError: name 'info' is not defined`. Added a bare `raise` to propagate unexpected errors.

### `README.md`

- Removed the "JSONBIN will not work at the moment" notice (now fixed)
- Added `-A`/`--use-aria2c`, `-SC`/`--specific-channel`, `-co`/`--cookies-file` flags to the usage block — all three were added in recent commits but were absent from the docs
- Corrected the `--timeout` default: README said 5.5h, code default is 5h

## Test plan

- [ ] Set `JSONBIN_KEY` and run `internetarchive-youtube -C` — confirm collection and bin are created correctly on a fresh account
- [ ] Run again — confirm existing collection/bin is found by name and not duplicated
- [ ] Confirm `update_bin` no longer accumulates versions in the JSONBin dashboard
- [ ] Feed `get_video_extension` a URL that triggers an unexpected yt-dlp error — confirm it raises rather than silently producing `NameError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)